### PR TITLE
Update build settings to V2

### DIFF
--- a/Source/GASDocumentation/GASDocumentation.cpp
+++ b/Source/GASDocumentation/GASDocumentation.cpp
@@ -1,6 +1,6 @@
 // Copyright 2019 Dan Kestranek.
 
-#include "GASDocumentation.h"
+#include "GASDocumentation/GASDocumentation.h"
 #include "Modules/ModuleManager.h"
 
 IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, GASDocumentation, "GASDocumentation" );

--- a/Source/GASDocumentation/GASDocumentation.h
+++ b/Source/GASDocumentation/GASDocumentation.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "UObject/ObjectMacros.h"
 
 #define ACTOR_ROLE_FSTRING *(FindObject<UEnum>(ANY_PACKAGE, TEXT("ENetRole"), true)->GetNameStringByValue(GetLocalRole()))
 #define GET_ACTOR_ROLE_FSTRING(Actor) *(FindObject<UEnum>(ANY_PACKAGE, TEXT("ENetRole"), true)->GetNameStringByValue(Actor->GetLocalRole()))

--- a/Source/GASDocumentation/GASDocumentationGameMode.cpp
+++ b/Source/GASDocumentation/GASDocumentationGameMode.cpp
@@ -1,10 +1,10 @@
 // Copyright 2019 Dan Kestranek.
 
-#include "GASDocumentationGameMode.h"
+#include "GASDocumentation/GASDocumentationGameMode.h"
 #include "Engine/World.h"
-#include "GDHeroCharacter.h"
-#include "GDPlayerController.h"
-#include "GDPlayerState.h"
+#include "Characters/Heroes/GDHeroCharacter.h"
+#include "Player/GDPlayerController.h"
+#include "Player/GDPlayerState.h"
 #include "GameFramework/SpectatorPawn.h"
 #include "Kismet/GameplayStatics.h"
 #include "TimerManager.h"

--- a/Source/GASDocumentation/Private/AI/GDHeroAIController.cpp
+++ b/Source/GASDocumentation/Private/AI/GDHeroAIController.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDHeroAIController.h"
+#include "AI/GDHeroAIController.h"
 
 AGDHeroAIController::AGDHeroAIController()
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/AbilityTasks/GDAT_PlayMontageAndWaitForEvent.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AbilityTasks/GDAT_PlayMontageAndWaitForEvent.cpp
@@ -1,11 +1,11 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDAT_PlayMontageAndWaitForEvent.h"
-#include "GASDocumentation.h"
-#include "GDAbilitySystemComponent.h"
+#include "Characters/Abilities/AbilityTasks/GDAT_PlayMontageAndWaitForEvent.h"
+#include "GASDocumentation/GASDocumentation.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
 #include "GameFramework/Character.h"
-#include "GDGameplayAbility.h"
+#include "Characters/Abilities/GDGameplayAbility.h"
 #include "AbilitySystemComponent.h"
 #include "AbilitySystemGlobals.h"
 #include "Animation/AnimInstance.h"

--- a/Source/GASDocumentation/Private/Characters/Abilities/AbilityTasks/GDAT_WaitReceiveDamage.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AbilityTasks/GDAT_WaitReceiveDamage.cpp
@@ -1,8 +1,8 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDAT_WaitReceiveDamage.h"
-#include "GDAbilitySystemComponent.h"
+#include "Characters/Abilities/AbilityTasks/GDAT_WaitReceiveDamage.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
 
 UGDAT_WaitReceiveDamage::UGDAT_WaitReceiveDamage(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskAttributeChanged.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskAttributeChanged.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "AsyncTaskAttributeChanged.h"
+#include "Characters/Abilities/AsyncTaskAttributeChanged.h"
 
 UAsyncTaskAttributeChanged* UAsyncTaskAttributeChanged::ListenForAttributeChange(UAbilitySystemComponent* AbilitySystemComponent, FGameplayAttribute Attribute)
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskCooldownChanged.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskCooldownChanged.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "AsyncTaskCooldownChanged.h"
+#include "Characters/Abilities/AsyncTaskCooldownChanged.h"
 
 UAsyncTaskCooldownChanged * UAsyncTaskCooldownChanged::ListenForCooldownChange(UAbilitySystemComponent * AbilitySystemComponent, FGameplayTagContainer InCooldownTags, bool InUseServerCooldown)
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskEffectStackChanged.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskEffectStackChanged.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "AsyncTaskEffectStackChanged.h"
+#include "Characters/Abilities/AsyncTaskEffectStackChanged.h"
 
 UAsyncTaskEffectStackChanged * UAsyncTaskEffectStackChanged::ListenForGameplayEffectStackChange(UAbilitySystemComponent * AbilitySystemComponent, FGameplayTag InEffectGameplayTag)
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/AttributeSets/GDAttributeSetBase.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AttributeSets/GDAttributeSetBase.cpp
@@ -1,12 +1,12 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDAttributeSetBase.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
 #include "GameplayEffect.h"
 #include "GameplayEffectExtension.h"
-#include "GDCharacterBase.h"
-#include "GDPlayerController.h"
-#include "UnrealNetwork.h"
+#include "Characters/GDCharacterBase.h"
+#include "Player/GDPlayerController.h"
+#include "Net/UnrealNetwork.h"
 
 UGDAttributeSetBase::UGDAttributeSetBase()
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/GDAbilitySystemComponent.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDAbilitySystemComponent.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDAbilitySystemComponent.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
 
 void UGDAbilitySystemComponent::ReceiveDamage(UGDAbilitySystemComponent * SourceASC, float UnmitigatedDamage, float MitigatedDamage)
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/GDDamageExecCalculation.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDDamageExecCalculation.cpp
@@ -1,9 +1,9 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDDamageExecCalculation.h"
-#include "GDAbilitySystemComponent.h"
-#include "GDAttributeSetBase.h"
+#include "Characters/Abilities/GDDamageExecCalculation.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
 
 // Declare the attributes to capture and define how we want to capture them from the Source and Target.
 struct GDDamageStatics

--- a/Source/GASDocumentation/Private/Characters/Abilities/GDGA_CharacterJump.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDGA_CharacterJump.cpp
@@ -1,9 +1,9 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDGA_CharacterJump.h"
-#include "GDCharacterBase.h"
-#include "GASDocumentation.h"
+#include "Characters/Abilities/GDGA_CharacterJump.h"
+#include "Characters/GDCharacterBase.h"
+#include "GASDocumentation/GASDocumentation.h"
 
 UGDGA_CharacterJump::UGDGA_CharacterJump()
 {

--- a/Source/GASDocumentation/Private/Characters/Abilities/GDGameplayAbility.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDGameplayAbility.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDGameplayAbility.h"
+#include "Characters/Abilities/GDGameplayAbility.h"
 #include "AbilitySystemComponent.h"
 #include "GameplayTagContainer.h"
 

--- a/Source/GASDocumentation/Private/Characters/GDCharacterBase.cpp
+++ b/Source/GASDocumentation/Private/Characters/GDCharacterBase.cpp
@@ -1,13 +1,13 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDCharacterBase.h"
-#include "Abilities/AttributeSets/GDAttributeSetBase.h"
-#include "Abilities/GDGameplayAbility.h"
+#include "Characters/GDCharacterBase.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
+#include "Characters/Abilities/GDGameplayAbility.h"
 #include "Components/CapsuleComponent.h"
-#include "GDAbilitySystemComponent.h"
-#include "GDCharacterMovementComponent.h"
-#include "GDDamageTextWidgetComponent.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
+#include "Characters/GDCharacterMovementComponent.h"
+#include "UI/GDDamageTextWidgetComponent.h"
 
 // Sets default values
 AGDCharacterBase::AGDCharacterBase(const class FObjectInitializer& ObjectInitializer) :

--- a/Source/GASDocumentation/Private/Characters/GDCharacterMovementComponent.cpp
+++ b/Source/GASDocumentation/Private/Characters/GDCharacterMovementComponent.cpp
@@ -1,10 +1,10 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDCharacterMovementComponent.h"
+#include "Characters/GDCharacterMovementComponent.h"
 #include "AbilitySystemComponent.h"
 #include "GameplayTagContainer.h"
-#include "GDCharacterBase.h"
+#include "Characters/GDCharacterBase.h"
 
 UGDCharacterMovementComponent::UGDCharacterMovementComponent()
 {

--- a/Source/GASDocumentation/Private/Characters/GDProjectile.cpp
+++ b/Source/GASDocumentation/Private/Characters/GDProjectile.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDProjectile.h"
+#include "Characters/GDProjectile.h"
 #include "GameFramework/ProjectileMovementComponent.h"
 
 // Sets default values

--- a/Source/GASDocumentation/Private/Characters/Heroes/Abilities/GDGA_FireGun.cpp
+++ b/Source/GASDocumentation/Private/Characters/Heroes/Abilities/GDGA_FireGun.cpp
@@ -1,11 +1,11 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDGA_FireGun.h"
+#include "Characters/Heroes/Abilities/GDGA_FireGun.h"
 #include "AbilitySystemComponent.h"
 #include "Camera/CameraComponent.h"
 #include "GameFramework/SpringArmComponent.h"
-#include "GDHeroCharacter.h"
+#include "Characters/Heroes/GDHeroCharacter.h"
 #include "Kismet/KismetMathLibrary.h"
 
 UGDGA_FireGun::UGDGA_FireGun()

--- a/Source/GASDocumentation/Private/Characters/Heroes/GDHeroCharacter.cpp
+++ b/Source/GASDocumentation/Private/Characters/Heroes/GDHeroCharacter.cpp
@@ -1,22 +1,23 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDHeroCharacter.h"
-#include "Abilities/AttributeSets/GDAttributeSetBase.h"
+#include "Characters/Heroes/GDHeroCharacter.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
 #include "AI/GDHeroAIController.h"
 #include "Camera/CameraComponent.h"
 #include "Components/CapsuleComponent.h"
 #include "Components/DecalComponent.h"
 #include "GameFramework/SpringArmComponent.h"
-#include "GASDocumentationGameMode.h"
-#include "GDAbilitySystemComponent.h"
-#include "GDPlayerController.h"
-#include "GDPlayerState.h"
+#include "GASDocumentation/GASDocumentationGameMode.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
+#include "Player/GDPlayerController.h"
+#include "Player/GDPlayerState.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "Kismet/GameplayStatics.h"
 #include "UI/GDFloatingStatusBarWidget.h"
 #include "UObject/ConstructorHelpers.h"
-#include "WidgetComponent.h"
+#include "Components/WidgetComponent.h"
+
 
 AGDHeroCharacter::AGDHeroCharacter(const class FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
 {

--- a/Source/GASDocumentation/Private/Characters/Minions/GDMinionCharacter.cpp
+++ b/Source/GASDocumentation/Private/Characters/Minions/GDMinionCharacter.cpp
@@ -1,13 +1,13 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDMinionCharacter.h"
+#include "Characters/Minions/GDMinionCharacter.h"
 #include "Components/CapsuleComponent.h"
-#include "GDAbilitySystemComponent.h"
-#include "GDAttributeSetBase.h"
-#include "GDFloatingStatusBarWidget.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
+#include "UI/GDFloatingStatusBarWidget.h"
 #include "Kismet/GameplayStatics.h"
-#include "WidgetComponent.h"
+#include "Components/WidgetComponent.h"
 
 AGDMinionCharacter::AGDMinionCharacter(const class FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
 {

--- a/Source/GASDocumentation/Private/Player/GDPlayerController.cpp
+++ b/Source/GASDocumentation/Private/Player/GDPlayerController.cpp
@@ -1,11 +1,11 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDPlayerController.h"
+#include "Player/GDPlayerController.h"
 #include "AbilitySystemComponent.h"
-#include "GDDamageTextWidgetComponent.h"
-#include "GDHeroCharacter.h"
-#include "GDPlayerState.h"
+#include "UI/GDDamageTextWidgetComponent.h"
+#include "Characters/Heroes/GDHeroCharacter.h"
+#include "Player/GDPlayerState.h"
 #include "UI/GDHUDWidget.h"
 
 void AGDPlayerController::CreateHUD()

--- a/Source/GASDocumentation/Private/Player/GDPlayerState.cpp
+++ b/Source/GASDocumentation/Private/Player/GDPlayerState.cpp
@@ -1,11 +1,11 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDPlayerState.h"
-#include "Abilities/AttributeSets/GDAttributeSetBase.h"
-#include "GDAbilitySystemComponent.h"
-#include "GDHeroCharacter.h"
-#include "GDPlayerController.h"
+#include "Player/GDPlayerState.h"
+#include "Characters/Abilities/AttributeSets/GDAttributeSetBase.h"
+#include "Characters/Abilities/GDAbilitySystemComponent.h"
+#include "Characters/Heroes/GDHeroCharacter.h"
+#include "Player/GDPlayerController.h"
 #include "UI/GDFloatingStatusBarWidget.h"
 #include "UI/GDHUDWidget.h"
 

--- a/Source/GASDocumentation/Private/UI/GDDamageTextWidgetComponent.cpp
+++ b/Source/GASDocumentation/Private/UI/GDDamageTextWidgetComponent.cpp
@@ -1,5 +1,5 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDDamageTextWidgetComponent.h"
+#include "UI/GDDamageTextWidgetComponent.h"
 

--- a/Source/GASDocumentation/Private/UI/GDFloatingStatusBarWidget.cpp
+++ b/Source/GASDocumentation/Private/UI/GDFloatingStatusBarWidget.cpp
@@ -1,5 +1,5 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDFloatingStatusBarWidget.h"
+#include "UI/GDFloatingStatusBarWidget.h"
 

--- a/Source/GASDocumentation/Private/UI/GDHUDWidget.cpp
+++ b/Source/GASDocumentation/Private/UI/GDHUDWidget.cpp
@@ -1,5 +1,5 @@
 // Copyright 2019 Dan Kestranek.
 
 
-#include "GDHUDWidget.h"
+#include "UI/GDHUDWidget.h"
 

--- a/Source/GASDocumentation/Public/Characters/Abilities/GDGameplayAbility.h
+++ b/Source/GASDocumentation/Public/Characters/Abilities/GDGameplayAbility.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Abilities/GameplayAbility.h"
-#include "GASDocumentation.h"
+#include "GASDocumentation/GASDocumentation.h"
 #include "GDGameplayAbility.generated.h"
 
 /**

--- a/Source/GASDocumentation/Public/Characters/GDCharacterBase.h
+++ b/Source/GASDocumentation/Public/Characters/GDCharacterBase.h
@@ -6,7 +6,7 @@
 #include "GameFramework/Character.h"
 #include "AbilitySystemInterface.h"
 #include "GameplayTagContainer.h"
-#include "GASDocumentation.h"
+#include "GASDocumentation/GASDocumentation.h"
 #include "GDCharacterBase.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCharacterBaseHitReactDelegate, EGDHitReactDirection, Direction);

--- a/Source/GASDocumentation/Public/Characters/Heroes/Abilities/GDGA_FireGun.h
+++ b/Source/GASDocumentation/Public/Characters/Heroes/Abilities/GDGA_FireGun.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Abilities/GDGameplayAbility.h"
-#include "Abilities/AbilityTasks/GDAT_PlayMontageAndWaitForEvent.h"
-#include "GDProjectile.h"
+#include "Characters/Abilities/GDGameplayAbility.h"
+#include "Characters/Abilities/AbilityTasks/GDAT_PlayMontageAndWaitForEvent.h"
+#include "Characters/GDProjectile.h"
 #include "GDGA_FireGun.generated.h"
 
 /**

--- a/Source/GASDocumentation/Public/Player/GDPlayerController.h
+++ b/Source/GASDocumentation/Public/Player/GDPlayerController.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/PlayerController.h"
-#include "GDCharacterBase.h"
+#include "Characters/GDCharacterBase.h"
 #include "GDPlayerController.generated.h"
 
 /**

--- a/Source/GASDocumentationEditor.Target.cs
+++ b/Source/GASDocumentationEditor.Target.cs
@@ -8,6 +8,7 @@ public class GASDocumentationEditorTarget : TargetRules
 	public GASDocumentationEditorTarget(TargetInfo Target) : base(Target)
 	{
 		Type = TargetType.Editor;
+		DefaultBuildSettings = BuildSettingsVersion.V2;
 		ExtraModuleNames.Add("GASDocumentation");
 	}
 }


### PR DESCRIPTION
First of all, thank you so much for making this project available. It's super helpful not only as a learning resource but also to get a nice, clean startup project that is already configured for using Gameplay Abilities.

I've changed the build system settings to V2 to get rid of a warning from UBT. This made it necessary to either adjust the includes to use more explicit paths or to set `bLegacyPublicIncludePaths` to false. Since I try to avoid backwards compatibility settings when possible I've decided to adjust the header paths, even if the change touches many files.
 
In case you also want to go down this route, this PR might save you a few minutes of adjusting the headers.