### PR TITLE
Fix misleading armor calculation

### DIFF
--- a/Source/GASDocumentation/Private/Characters/Abilities/GDDamageExecCalculation.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDDamageExecCalculation.cpp
@@ -59,8 +59,7 @@ void UGDDamageExecCalculation::Execute_Implementation(const FGameplayEffectCusto
 	EvaluationParameters.SourceTags = SourceTags;
 	EvaluationParameters.TargetTags = TargetTags;
 
-	float Armor = 0.0f;
-	FMath::Max<float>(ExecutionParams.AttemptCalculateCapturedAttributeMagnitude(DamageStatics().ArmorDef, EvaluationParameters, Armor), 0.0f);
+	float Armor = FMath::Max<float>(ExecutionParams.AttemptCalculateCapturedAttributeMagnitude(DamageStatics().ArmorDef, EvaluationParameters, Armor), 0.0f);
 
 	// SetByCaller Damage
 	float Damage = FMath::Max<float>(Spec.GetSetByCallerMagnitude(FGameplayTag::RequestGameplayTag(FName("Data.Damage")), false, -1.0f), 0.0f);


### PR DESCRIPTION
FMath::Max return value was not assigned to Armor variable. Misleading intent of line