### PR TITLE
EffectContext subclasses need TStructOpsTypeTraits

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ To subclass the `GameplayEffectContext`:
 1. Override `FGameplayEffectContext::GetScriptStruct()`
 1. Override `FGameplayEffectContext::Duplicate()`
 1. Override `FGameplayEffectContext::NetSerialize()` if your new data needs to be replicated
-1. If you overrode `FGameplayEffectContext::NetSerialize()`, be sure to make the `TStructOpsTypeTraits` like the parent struct `FGameplayEffectContext` has
+1. Implement `TStructOpsTypeTraits` for your subclass, like the parent struct `FGameplayEffectContext` has
 1. Override `AllocGameplayEffectContext()` in your [`AbilitySystemGlobals`](#concepts-asg) class to return a new object of your subclass
 
 **[⬆ Back to Top](#table-of-contents)**


### PR DESCRIPTION
GameplayEffectTypes.cpp:333 requires FGameplayEffectContext or whatever subclass you're using to have the STRUCT_NetSerializeNative flag on its ScriptStruct.

TStructOpsTypeTraits is what determines the flags that are set on a struct's ScriptStruct, and since type traits are independent of the inheritance hierarchy, the flags don't get inherited. 
This means that even if you don't override the NetSerialize method, you still need to tell the reflection system that your subclass has a natively implemented NetSerialize function (the one on FGameplayEffectContext).