### PR TITLE
Mention that `showdebug abilitysystem` only works with valid HUD class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2801,6 +2801,8 @@ The third page shows all of the `GameplayAbilities` that have been granted to yo
 
 While you can cycle between targets with `PageUp` and `PageDown`, the pages will only show data for the `ASC` on your locally controlled `Character`. However, using `AbilitySystem.Debug.NextTarget` and `AbilitySystem.Debug.PrevTarget` will show data for other `ASCs`, but it will not update the top half of the debug information nor will it update the green targeting rectangular prism so there is no way to know which `ASC` is currently being targeted. This bug has been reported https://issues.unrealengine.com/issue/UE-90437.
 
+**Note:** For `showdebug abilitysystem` to work an actual HUD class must be selected in the GameMode. Otherwise the command is not found an "Unknown Command" is returned.
+
 **[⬆ Back to Top](#table-of-contents)**
 
 <a name="debugging-gd"></a>

--- a/README.md
+++ b/README.md
@@ -2801,7 +2801,7 @@ The third page shows all of the `GameplayAbilities` that have been granted to yo
 
 While you can cycle between targets with `PageUp` and `PageDown`, the pages will only show data for the `ASC` on your locally controlled `Character`. However, using `AbilitySystem.Debug.NextTarget` and `AbilitySystem.Debug.PrevTarget` will show data for other `ASCs`, but it will not update the top half of the debug information nor will it update the green targeting rectangular prism so there is no way to know which `ASC` is currently being targeted. This bug has been reported https://issues.unrealengine.com/issue/UE-90437.
 
-**Note:** For `showdebug abilitysystem` to work an actual HUD class must be selected in the GameMode. Otherwise the command is not found an "Unknown Command" is returned.
+**Note:** For `showdebug abilitysystem` to work an actual HUD class must be selected in the GameMode. Otherwise the command is not found and "Unknown Command" is returned.
 
 **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
If you have no HUD class set in your gamemode (someone cleared it, old one was deleted or some other issue. You no longer can use `showdebug abilitysystem` in console to easily debug GAS.

Thus added a note for other people reading this, and stumbling across it. As it took me quite a while to find out.