### PR TITLE
Update AcknowledgePossession() name

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,12 +319,12 @@ AGDPlayerState::AGDPlayerState()
 
 The `ASC` needs to be initialized with its `OwnerActor` and `AvatarActor` on both the server and the client. You want to initialize after the `Pawn's` `Controller` has been set (after possession). Single player games only need to worry about the server path.
 
-For player controlled characters where the `ASC` lives on the `Pawn`, I typically initialize on the server in the `Pawn's` `PossessedBy()` function and initialize on the client in the `PlayerController's` `AcknowledgePawn()` function.
+For player controlled characters where the `ASC` lives on the `Pawn`, I typically initialize on the server in the `Pawn's` `PossessedBy()` function and initialize on the client in the `PlayerController's` `OnPossess()` function.
 
 ```c++
-void APACharacterBase::PossessedBy(AController * NewController)
+void APACharacterBase::OnPossess(AController * NewController)
 {
-	Super::PossessedBy(NewController);
+	Super::OnPossess(NewController);
 
 	if (AbilitySystemComponent)
 	{


### PR DESCRIPTION
Hello,
I couldn't find the `AcknowledgePossession()` nor the `AcknowledgePawn()` function anywhere in UE's codebase.
I think it's now called `OnPossess()`.
Thanks for the hard work!