### PR TITLE
Use correct activation info for ending jump

### DIFF
--- a/Source/GASDocumentation/Private/Characters/Abilities/GDGA_CharacterJump.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/GDGA_CharacterJump.cpp
@@ -19,7 +19,7 @@ void UGDGA_CharacterJump::ActivateAbility(const FGameplayAbilitySpecHandle Handl
 	{
 		if (!CommitAbility(Handle, ActorInfo, ActivationInfo))
 		{
-			EndAbility(CurrentSpecHandle, CurrentActorInfo, CurrentActivationInfo, true, true);
+			EndAbility(Handle, ActorInfo, ActivationInfo, true, true);
 		}
 
 		ACharacter * Character = CastChecked<ACharacter>(ActorInfo->AvatarActor.Get());


### PR DESCRIPTION
An ability's `CurrentSpecHandle`, `CurrentActorInfo` and `CurrentActivationInfo` are not set when the abiilty is non-instanced.
Passing them to `EndAbility` will make the call silently fail (because `IsEndAbilityValid` fails to get a pointer to the ASC from the `ActorInfo`), so the ability never ends.
The callsite in the jump ability was likely never called so it didn't cause any issues, but it's better to be consistent in case someone uses it as reference.