### PR TITLE
[FIX] Attribute initialisation now gets properly initialised in server and client

### DIFF
--- a/Source/GASDocumentation/Private/Characters/GDCharacterBase.cpp
+++ b/Source/GASDocumentation/Private/Characters/GDCharacterBase.cpp
@@ -308,7 +308,22 @@ void AGDCharacterBase::InitializeAttributes()
 	FGameplayEffectSpecHandle NewHandle = AbilitySystemComponent->MakeOutgoingSpec(DefaultAttributes, GetCharacterLevel(), EffectContext);
 	if (NewHandle.IsValid())
 	{
-		FActiveGameplayEffectHandle ActiveGEHandle = AbilitySystemComponent->ApplyGameplayEffectSpecToTarget(*NewHandle.Data.Get(), AbilitySystemComponent.Get());
+		FGameplayEffectSpec Spec = *NewHandle.Data.Get();
+		float AppliedMagnitude = 0.f;
+		for (const FGameplayModifierInfo& ModifierInfo : Spec.Def->Modifiers)
+		{
+			if (Spec.Def->DurationPolicy == EGameplayEffectDurationType::Instant)
+			{
+				if (ModifierInfo.ModifierMagnitude.AttemptCalculateMagnitude(Spec, AppliedMagnitude))
+				{
+					AbilitySystemComponent->SetNumericAttributeBase(ModifierInfo.Attribute, AppliedMagnitude);
+				}
+			}
+			else
+			{
+				UE_LOG(LogTemp, Error, TEXT("Initializer %s does not apply an Instant Duration Policy."), *Spec.Def->GetName());
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
I have some non replicated attributes I'd like to initialise in both, Authority and Autonomous Proxy.

For that I am adding an initializer gameplay effect in the character in PossessedBy (auth) and OnRepPlayerState (aut/sim-proxy).

Well turns out that GASDocumentation ASC lives in the PS, and when I am adding the effect in OnRep_PlayerState, my attributes dont get initialised in the autonomous proxy, but the simulated proxies... i could diagnose a bit, and it seems that even if the character is autonomous proxy in onrep_playerstate, the PS is simulated proxy... so I effectively dont have a way to init non replicated Attributes in the Autonomous Proxy through the offered original method. 

TODO: Address this in the documentation since I find it pretty relevant for ASCs that live in the PS.