### PR TITLE
Set EvaluateWithBase Division to be cumulative too

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,6 +972,7 @@ float FAggregatorModChannel::EvaluateWithBase(float InlineBaseValue, const FAggr
 {
 	...
 	float Multiplicitive = MultiplyMods(Mods[EGameplayModOp::Multiplicitive], Parameters);
+	float Division = MultiplyMods(Mods[EGameplayModOp::Division], Parameters);
 	...
 
 	return ((InlineBaseValue + Additive) * Multiplicitive) / Division;


### PR DESCRIPTION
The text propose a modification to make Division and multiplication cumulative, but the code proposed was showing only the multiplication