### PR TITLE
Added code examples for Target Data section, showing inheritance and general usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2694,6 +2694,7 @@ FName GetCoolNameFromTargetData(const FGameplayAbilityTargetDataHandle& Handle, 
 	// Here is when you would do the cast because we know its the correct type already
     	FGameplayAbilityTargetData_CustomData* CustomData = static_cast<FGameplayAbilityTargetData_CustomData*>(data);
     	return CustomData->CoolName;
+}
 ```
 
 **[⬆ Back to Top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -2676,9 +2676,9 @@ For getting values it requires doing type safety checking, because the only way 
 - Script Struct & Static Structs: You can instead do direct class comparison(which can involve a lot of IF statements or making some template functions), below is an example of doing this but basically you can get the script struct from any `FGameplayAbilityTargetData`(this is a nice advantage of it being a `USTRUCT` and requiring any inherited classes to specify the struct type in `GetScriptStruct`) and compare if its the type you're looking for. Below is an example of using these functions for type checking:
 ```c++
 UFUNCTION(BlueprintPure)
-FName GetCoolNameFromTargetData(const FGameplayAbilityTargetDataHandle& Handle)
+FName GetCoolNameFromTargetData(const FGameplayAbilityTargetDataHandle& Handle, const int Index)
 {
-	FGameplayAbilityTargetData* data = Handle.Data[0].Get();
+	FGameplayAbilityTargetData* data = Handle.Data[Index].Get();
 	// Valid check we have something to use, null data means nothing to cast for
 	if(data == nullptr)
 	{

--- a/README.md
+++ b/README.md
@@ -2607,7 +2607,7 @@ Epic recently started an initiative to replace the `CharacterMovementComponent` 
 
 We don't typically pass around the `FGameplayAbilityTargetData` directly, instead we use a [`FGameplayAbilityTargetDataHandle`](https://docs.unrealengine.com/en-US/API/Plugins/GameplayAbilities/Abilities/FGameplayAbilityTargetDataHandle/index.html) which has an internal TArray of pointers to `FGameplayAbilityTargetData`. This intermediate struct provides support for polymorphism of the `TargetData`.
 
-An example of inherited from `FGameplayAbilityTargetData`:
+An example of inheritting from `FGameplayAbilityTargetData`:
 ```c++
 USTRUCT(BlueprintType)
 struct MYGAME_API FGameplayAbilityTargetData_CustomData : public FGameplayAbilityTargetData

--- a/README.md
+++ b/README.md
@@ -2607,6 +2607,95 @@ Epic recently started an initiative to replace the `CharacterMovementComponent` 
 
 We don't typically pass around the `FGameplayAbilityTargetData` directly, instead we use a [`FGameplayAbilityTargetDataHandle`](https://docs.unrealengine.com/en-US/API/Plugins/GameplayAbilities/Abilities/FGameplayAbilityTargetDataHandle/index.html) which has an internal TArray of pointers to `FGameplayAbilityTargetData`. This intermediate struct provides support for polymorphism of the `TargetData`.
 
+An example of inherited from `FGameplayAbilityTargetData`:
+```c++
+USTRUCT(BlueprintType)
+struct MYGAME_API FGameplayAbilityTargetData_CustomData : public FGameplayAbilityTargetData
+{
+        GENERATED_BODY()
+public:
+
+        FGameplayAbilityTargetData_CustomData()
+        { }
+
+        UPROPERTY()
+        FName CoolName = NAME_None;
+
+        UPROPERTY()
+        FPredictionKey MyCoolPredictionKey;
+
+	// This is required for all child structs of FGameplayAbilityTargetData
+	virtual UScriptStruct* GetScriptStruct() const override
+	{
+		return FGameplayAbilityTargetData_CustomData::StaticStruct();
+	}
+
+	// This is required for all child structs of FGameplayAbilityTargetData
+        bool NetSerialize(FArchive& Ar, class UPackageMap* Map, bool& bOutSuccess)
+        {
+		// The engine already defined NetSerialize for FName & FPredictionKey, thanks Epic!
+                CoolName.NetSerialize(Ar, Map, bOutSuccess);
+                MyCoolPredictionKey.NetSerialize(Ar, Map, bOutSuccess);
+                bOutSuccess = true;
+                return true;
+        }
+}
+
+template<>
+struct TStructOpsTypeTraits<FGameplayAbilityTargetData_CustomData> : public TStructOpsTypeTraitsBase2<FGameplayAbilityTargetData_CustomData>
+{
+	enum
+	{
+		WithNetSerializer = true // This is REQUIRED for FGameplayAbilityTargetDataHandle net serialization to work
+	};
+};
+```
+For adding the target data to a handle:
+```c++
+UFUNCTION(BlueprintPure)
+FGameplayAbilityTargetDataHandle MakeTargetDataFromCustomName(const FName CustomName)
+{
+	// Create our target data type, 
+	// Handle's automatically cleanup and delete this data when the handle is destructed, 
+	// if you don't add this to a handle then be careful because this deals with memory management and memory leaks so its safe to just always add it to a handle at some point in the frame!
+	FGameplayAbilityTargetData_CustomData* MyCustomData = new FGameplayAbilityTargetData_CustomData();
+	// Setup the struct's information to use the inputted name and any other changes we may want to do
+	MyCustomData->CoolName = CustomName;
+	
+	// Make our handle wrapper for Blueprint usage
+	FGameplayAbilityTargetDataHandle Handle;
+	// Add the target data to our handle
+	Handle.Add(MyCustomData);
+	// Output our handle to Blueprint
+	return Handle
+}
+```
+
+For getting values it requires doing type safety checking, because the only way to get values from the handle's target data is by using generic C/C++ casting for it which is *NOT* type safe which can cause object slicing and crashes. For type checking there are multiple ways of doing this(however you want honestly) two common ways are:
+- Gameplay Tag(s): You can use a subclass hierarchy where you know that anytime a ceratain code architcture's functionality occurs, you can cast for the base parent type and get its gameplay tag(s) and then compare against those for casting for inherited classes.
+- Script Struct & Static Structs: You can instead do direct class comparison(which can involve a lot of IF statements or making some template functions), below is an example of doing this but basically you can get the script struct from any `FGameplayAbilityTargetData`(this is a nice advantage of it being a `USTRUCT` and requiring any inherited classes to specify the struct type in `GetScriptStruct`) and compare if its the type you're looking for. Below is an example of using these functions for type checking:
+```c++
+UFUNCTION(BlueprintPure)
+FName GetCoolNameFromTargetData(const FGameplayAbilityTargetDataHandle& Handle)
+{
+	FGameplayAbilityTargetData* data = Handle.Data[0].Get();
+	// Valid check we have something to use, null data means nothing to cast for
+	if(data == nullptr)
+	{
+		// NAME_None is a static value for FName's as a safe "None" value
+    		return NAME_None;
+	}
+	// This is basically the type checking pass, static_cast does not have type safety, this is why we do this check.
+	// If we don't do this then it will object slice the struct and thus we have no way of making sure its that type.
+	if(data->GetScriptStruct() == FGameplayAbilityTargetData_CustomData::StaticStruct())
+	{
+    		return NAME_None;
+	}
+	// Here is when you would do the cast because we know its the correct type already
+    	FGameplayAbilityTargetData_CustomData* CustomData = static_cast<FGameplayAbilityTargetData_CustomData*>(data);
+    	return CustomData->CoolName;
+```
+
 **[⬆ Back to Top](#table-of-contents)**
 
 <a name="concepts-targeting-actors"></a>


### PR DESCRIPTION
Issue associated: https://github.com/tranek/GASDocumentation/issues/75

This is to add some sort of examples for target data on how to:
- Inherit from `FGameplayAbilityTargetData`
- How to create a `FGameplayAbilityTargetDataHandle` that uses this type
- How to type check for the inherited `FGameplayAbilityTargetData`
- How to cast for `FGameplayAbilityTargetData`