### PR TITLE
Remove registered StackChange callback on EndTask

### DIFF
--- a/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskEffectStackChanged.cpp
+++ b/Source/GASDocumentation/Private/Characters/Abilities/AsyncTaskEffectStackChanged.cpp
@@ -27,6 +27,11 @@ void UAsyncTaskEffectStackChanged::EndTask()
 	{
 		ASC->OnActiveGameplayEffectAddedDelegateToSelf.RemoveAll(this);
 		ASC->OnAnyGameplayEffectRemovedDelegate().RemoveAll(this);
+		
+		if(ActiveEffectHandle.IsValid())
+		{
+			ASC->OnGameplayEffectStackChangeDelegate(ActiveEffectHandle)->RemoveAll(this);
+		}
 	}
 
 	SetReadyToDestroy();
@@ -45,6 +50,7 @@ void UAsyncTaskEffectStackChanged::OnActiveGameplayEffectAddedCallback(UAbilityS
 	{
 		ASC->OnGameplayEffectStackChangeDelegate(ActiveHandle)->AddUObject(this, &UAsyncTaskEffectStackChanged::GameplayEffectStackChanged);
 		OnGameplayEffectStackChange.Broadcast(EffectGameplayTag, ActiveHandle, 1, 0);
+		ActiveEffectHandle = ActiveHandle;
 	}
 }
 

--- a/Source/GASDocumentation/Public/Characters/Abilities/AsyncTaskEffectStackChanged.h
+++ b/Source/GASDocumentation/Public/Characters/Abilities/AsyncTaskEffectStackChanged.h
@@ -35,6 +35,8 @@ protected:
 
 	FGameplayTag EffectGameplayTag;
 
+	FActiveGameplayEffectHandle ActiveEffectHandle;
+
 	virtual void OnActiveGameplayEffectAddedCallback(UAbilitySystemComponent* Target, const FGameplayEffectSpec& SpecApplied, FActiveGameplayEffectHandle ActiveHandle);
 	virtual void OnRemoveGameplayEffectCallback(const FActiveGameplayEffect& EffectRemoved);
 


### PR DESCRIPTION
Looking at AbilityTask_WaitGameplayEffectStackChange, it seems like we should probably be removing that On..ChangeDelegate in addition to the Added/Removed delegates.