### PR TITLE
Updated instructions for changing debugging targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2946,7 +2946,7 @@ The second page shows all of the `Duration` and `Infinite` `GameplayEffects` on 
 The third page shows all of the `GameplayAbilities` that have been granted to you, whether they are currently running, whether they are blocked from activating, and the status of currently running `AbilityTasks`.
 ![Third Page of showdebug abilitysystem](https://github.com/tranek/GASDocumentation/raw/master/Images/showdebugpage3.png)
 
-While you can cycle between targets with `PageUp` and `PageDown`, the pages will only show data for the `ASC` on your locally controlled `Character`. However, using `AbilitySystem.Debug.NextTarget` and `AbilitySystem.Debug.PrevTarget` will show data for other `ASCs`, but it will not update the top half of the debug information nor will it update the green targeting rectangular prism so there is no way to know which `ASC` is currently being targeted. This bug has been reported https://issues.unrealengine.com/issue/UE-90437.
+While you can cycle between targets with `PageUp` and `PageDown`, the pages will only show data for the `ASC` on your locally controlled `Character` by default. This can however be fixed by adding `bUseDebugTargetFromHud=True` to the `AbilitySystemGlobals` section in your `DefaultGame.ini` config file.
 
 **Note:** For `showdebug abilitysystem` to work an actual HUD class must be selected in the GameMode. Otherwise the command is not found and "Unknown Command" is returned.
 


### PR DESCRIPTION
In 5.1 the commands `AbilitySystem.Debug.NextTarget` and `AbilitySystem.Debug.PrevTarget` no longer seems to exist. Furthermore, a proper fix exists for the `PageUp` and `PageDown` buttons not working by changing the DefaultGame ini: https://github.com/EpicGames/UnrealEngine/pull/8139#issuecomment-1378589411

I have changed the readme to reflect this. I have confirmed that this works in 5.1, but like the original poster, I'm not 100% sure when the fix was introduced. Not sure if you want to include that information in the readme or not.